### PR TITLE
Downgrading clojure version to 1.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,21 +1,34 @@
 (def es-client-version "5.4.2")
-(defproject cc.qbits/spandex "0.5.1"
+(defproject cc.qbits/spandex "0.5.2-SNAPSHOT"
   :description "Clojure Wrapper of the new/official ElasticSearch REST client"
-  :url "https://github.com/mpenet/spandex"
+  :aot :all
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 ;;[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/core.async "0.3.443"]
                  [org.elasticsearch.client/rest ~es-client-version]
-                 [org.elasticsearch.client/sniffer ~es-client-version]
+;;                 [org.elasticsearch.client/sniffer ~es-client-version]
                  [cc.qbits/commons "0.4.6"]
                  [cheshire "5.7.1"]]
   :source-paths ["src/clj"]
   :global-vars {*warn-on-reflection* true}
-  :codox {:source-uri "https://github.com/mpenet/spandex/blob/master/{filepath}#L{line}"
-          :metadata {:doc/format :markdown}
-          :output-path "docs"
-          :doc-files ["docs/quickstart.md"]
-          :source-paths ["src/clj"]}
+  ;; :codox {:source-uri "https://github.com/mpenet/spandex/blob/master/{filepath}#L{line}"
+  ;;         :metadata {:doc/format :markdown}
+  ;;         :output-path "docs"
+  ;;         :doc-files ["docs/quickstart.md"]
+  ;;         :source-paths ["src/clj"]}
   :profiles {:dev {:plugins [[lein-cljfmt "0.5.6"]
-                             [codox "0.10.3"]]}})
+                             [codox "0.10.3"]]}}
+
+  :plugins [[lein-modules "0.3.9"]
+            [s3-wagon-private "1.1.2"]]
+  :repositories [["releases"
+                  {:url "s3p://shareablee-jar-repo/releases"
+                   :username :env/shareablee_aws_access_key
+                   :passphrase :env/shareablee_aws_secret_access_key
+                   :sign-releases false}]
+                 ["snapshots"
+                  {:url "s3p://shareablee-jar-repo/snapshots"
+                   :username :env/shareablee_aws_access_key
+                   :passphrase :env/shareablee_aws_secret_access_key}]])

--- a/src/clj/qbits/spandex/client_options.clj
+++ b/src/clj/qbits/spandex/client_options.clj
@@ -18,9 +18,9 @@
     RestClient
     RestClientBuilder
     RestClientBuilder$RequestConfigCallback
-    RestClientBuilder$HttpClientConfigCallback)
-   (org.elasticsearch.client.sniff
-    SniffOnFailureListener)))
+    RestClientBuilder$HttpClientConfigCallback)))
+   ;; (org.elasticsearch.client.sniff
+   ;;  SniffOnFailureListener)))
 
 ;; request opts
 (defmulti set-request-option! (fn [k builder option] k))
@@ -168,12 +168,12 @@
                    builder
                    options))))))
 
-(defmethod set-option! :sniff-on-failure
-  [_ ^RestClientBuilder builder sniffer]
-  (let [listener (SniffOnFailureListener.)]
-    (set-option! :failure-listener builder listener)
-    (.setSniffer listener sniffer))
-  builder)
+;; (defmethod set-option! :sniff-on-failure
+;;   [_ ^RestClientBuilder builder sniffer]
+;;   (let [listener (SniffOnFailureListener.)]
+;;     (set-option! :failure-listener builder listener)
+;;     (.setSniffer listener sniffer))
+;;   builder)
 
 (defmethod set-option! :failure-listener
   [_ ^RestClientBuilder builder failure-listener]

--- a/src/clj/qbits/spandex/sniffer_options.clj
+++ b/src/clj/qbits/spandex/sniffer_options.clj
@@ -1,32 +1,32 @@
-(ns qbits.spandex.sniffer-options
-  (:import
-   (org.elasticsearch.client.sniff
-    SnifferBuilder
-    Sniffer)))
+(ns qbits.spandex.sniffer-options)
+;;   (:import
+;;    (org.elasticsearch.client.sniff
+;;     SnifferBuilder
+;;     Sniffer)))
 
-(defmulti ^:no-doc set-option! (fn [k builder option] k))
+;; (defmulti ^:no-doc set-option! (fn [k builder option] k))
 
-(defmethod set-option! :sniff-interval
-  [_ ^SnifferBuilder builder interval]
-  (-> builder (.setSniffIntervalMillis (int interval))))
+;; (defmethod set-option! :sniff-interval
+;;   [_ ^SnifferBuilder builder interval]
+;;   (-> builder (.setSniffIntervalMillis (int interval))))
 
-(defmethod set-option! :sniff-after-failure-delay
-  [_ ^SnifferBuilder builder delay]
-  (-> builder (.setSniffAfterFailureDelayMillis (int delay))))
+;; (defmethod set-option! :sniff-after-failure-delay
+;;   [_ ^SnifferBuilder builder delay]
+;;   (-> builder (.setSniffAfterFailureDelayMillis (int delay))))
 
-(defmethod set-option! :default
-  [_ ^SnifferBuilder b x]
-  b)
+;; (defmethod set-option! :default
+;;   [_ ^SnifferBuilder b x]
+;;   b)
 
-(defn ^:no-doc set-options! ^SnifferBuilder
-  [^SnifferBuilder builder options]
-  (reduce (fn [builder [k option]]
-            (set-option! k builder option))
-          builder
-          options))
+;; (defn ^:no-doc set-options! ^SnifferBuilder
+;;   [^SnifferBuilder builder options]
+;;   (reduce (fn [builder [k option]]
+;;             (set-option! k builder option))
+;;           builder
+;;           options))
 
-(defn builder [client sniffer options]
-  (-> (Sniffer/builder client)
-      (.setHostsSniffer sniffer)
-      (set-options! options)
-      .build))
+;; (defn builder [client sniffer options]
+;;   (-> (Sniffer/builder client)
+;;       (.setHostsSniffer sniffer)
+;;       (set-options! options)
+;;       .build))

--- a/src/clj/qbits/spandex/spec.clj
+++ b/src/clj/qbits/spandex/spec.clj
@@ -1,187 +1,187 @@
-(ns qbits.spandex.spec
-  (:require
-   [qbits.spandex]
-   [clojure.spec.alpha :as s]
-   [clojure.core.async :as async]
-   [qbits.spandex.url])
-  (:import
-   (java.net InetAddress)
-   (javax.net.ssl SSLContext)
-   (org.elasticsearch.client
-    RestClient
-    RestClient$FailureListener)))
+;; (ns qbits.spandex.spec
+;;   (:require
+;;    [qbits.spandex]
+;;    [clojure.spec.alpha :as s]
+;;    [clojure.core.async :as async]
+;;    [qbits.spandex.url])
+;;   (:import
+;;    (java.net InetAddress)
+;;    (javax.net.ssl SSLContext)
+;;    (org.elasticsearch.client
+;;     RestClient
+;;     RestClient$FailureListener)))
 
-(s/def ::chan
-  #(instance? clojure.core.async.impl.channels.ManyToManyChannel %))
+;; (s/def ::chan
+;;   #(instance? clojure.core.async.impl.channels.ManyToManyChannel %))
 
-(s/def ::client #(instance? RestClient %))
+;; (s/def ::client #(instance? RestClient %))
 
-(alias 'client-options (create-ns 'qbits.spandex.spec.client-options))
-(s/def ::client-options (s/keys :opt-un [::client-options/max-retry-timeout
-                                         ::client-options/default-headers
-                                         ::client-options/failure-listener
-                                         ::client-options/http-client
-                                         ::client-options/request]))
+;; (alias 'client-options (create-ns 'qbits.spandex.spec.client-options))
+;; (s/def ::client-options (s/keys :opt-un [::client-options/max-retry-timeout
+;;                                          ::client-options/default-headers
+;;                                          ::client-options/failure-listener
+;;                                          ::client-options/http-client
+;;                                          ::client-options/request]))
 
-(s/def ::client-options/failure-listener #(instance? RestClient$FailureListener %))
-(s/def ::client-options/max-retry-timeout int?)
-(s/def ::client-options/default-headers (s/map-of (s/or :kw keyword? :str string?)
-                                                  string?))
+;; (s/def ::client-options/failure-listener #(instance? RestClient$FailureListener %))
+;; (s/def ::client-options/max-retry-timeout int?)
+;; (s/def ::client-options/default-headers (s/map-of (s/or :kw keyword? :str string?)
+;;                                                   string?))
 
-(alias 'http-client-options (create-ns 'qbits.spandex.spec.client-options.http-client))
-(alias 'basic-auth
-       (create-ns 'qbits.spandex.spec.client-options.http-client.basic-auth))
-(s/def ::client-options/http-client
-  (s/keys :opt-un [::http-client-options/max-conn-per-route
-                   ::http-client-options/max-conn-total
-                   ::http-client-options/proxy
-                   ::http-client-options/ssl-context
-                   ::http-client-options/user-agent
-                   ::http-client-options/basic-auth
-                   ::http-client-options/auth-caching?
-                   ::http-client-options/cookie-management?]))
-(s/def ::http-client-options/max-conn-per-route pos-int?)
-(s/def ::http-client-options/max-conn-total pos-int?)
-(s/def ::http-client-options/user-agent string?)
-(s/def ::http-client-options/auth-caching? boolean?)
-(s/def ::http-client-options/cookie-management? boolean?)
-(s/def ::http-client-options/basic-auth
-  (s/keys :req-un [::basic-auth/user
-                   ::basic-auth/password]))
-(s/def ::http-client-options/ssl-context #(instance? SSLContext %))
-(s/def ::http-client-options/proxy any?)
-(s/def ::basic-auth/user string?)
-(s/def ::basic-auth/password string?)
+;; (alias 'http-client-options (create-ns 'qbits.spandex.spec.client-options.http-client))
+;; (alias 'basic-auth
+;;        (create-ns 'qbits.spandex.spec.client-options.http-client.basic-auth))
+;; (s/def ::client-options/http-client
+;;   (s/keys :opt-un [::http-client-options/max-conn-per-route
+;;                    ::http-client-options/max-conn-total
+;;                    ::http-client-options/proxy
+;;                    ::http-client-options/ssl-context
+;;                    ::http-client-options/user-agent
+;;                    ::http-client-options/basic-auth
+;;                    ::http-client-options/auth-caching?
+;;                    ::http-client-options/cookie-management?]))
+;; (s/def ::http-client-options/max-conn-per-route pos-int?)
+;; (s/def ::http-client-options/max-conn-total pos-int?)
+;; (s/def ::http-client-options/user-agent string?)
+;; (s/def ::http-client-options/auth-caching? boolean?)
+;; (s/def ::http-client-options/cookie-management? boolean?)
+;; (s/def ::http-client-options/basic-auth
+;;   (s/keys :req-un [::basic-auth/user
+;;                    ::basic-auth/password]))
+;; (s/def ::http-client-options/ssl-context #(instance? SSLContext %))
+;; (s/def ::http-client-options/proxy any?)
+;; (s/def ::basic-auth/user string?)
+;; (s/def ::basic-auth/password string?)
 
-(alias 'request-options (create-ns 'qbits.spandex.spec.client-options.request))
-(s/def ::client-options/request
-  (s/keys :opt-un [::request-options/authentication?
-                   ::request-options/circular-redirect-allowed?
-                   ::request-options/connect-timeout
-                   ::request-options/connect-request-timeout
-                   ::request-options/content-compression?
-                   ::request-options/cookie-spec
-                   ::request-options/decompression?
-                   ::request-options/expect-continue?
-                   ::request-options/local-address
-                   ::request-options/cookie-spec
-                   ::request-options/max-redirects
-                   ::request-options/proxy
-                   ::request-options/redirects?
-                   ::request-options/relative-redirects-allowed?
-                   ::request-options/socket-timeout
-                   ::request-options/target-preferred-auth-schemes]))
-(s/def ::request-options/authentication? boolean?)
-(s/def ::request-options/circular-redirect-allowed? boolean?)
-(s/def ::request-options/content-compression? boolean?)
-(s/def ::request-options/decompression? boolean?)
-(s/def ::request-options/expect-continue? boolean?)
-(s/def ::request-options/redirect? boolean?)
-(s/def ::request-options/relative-redirects-allowed? boolean?)
+;; (alias 'request-options (create-ns 'qbits.spandex.spec.client-options.request))
+;; (s/def ::client-options/request
+;;   (s/keys :opt-un [::request-options/authentication?
+;;                    ::request-options/circular-redirect-allowed?
+;;                    ::request-options/connect-timeout
+;;                    ::request-options/connect-request-timeout
+;;                    ::request-options/content-compression?
+;;                    ::request-options/cookie-spec
+;;                    ::request-options/decompression?
+;;                    ::request-options/expect-continue?
+;;                    ::request-options/local-address
+;;                    ::request-options/cookie-spec
+;;                    ::request-options/max-redirects
+;;                    ::request-options/proxy
+;;                    ::request-options/redirects?
+;;                    ::request-options/relative-redirects-allowed?
+;;                    ::request-options/socket-timeout
+;;                    ::request-options/target-preferred-auth-schemes]))
+;; (s/def ::request-options/authentication? boolean?)
+;; (s/def ::request-options/circular-redirect-allowed? boolean?)
+;; (s/def ::request-options/content-compression? boolean?)
+;; (s/def ::request-options/decompression? boolean?)
+;; (s/def ::request-options/expect-continue? boolean?)
+;; (s/def ::request-options/redirect? boolean?)
+;; (s/def ::request-options/relative-redirects-allowed? boolean?)
 
-(s/def ::request-options/connect-timeout pos-int?)
-(s/def ::request-options/connect-request-timeout pos-int?)
-(s/def ::request-options/max-redirects int?)
-(s/def ::request-options/socket-timeout pos-int?)
+;; (s/def ::request-options/connect-timeout pos-int?)
+;; (s/def ::request-options/connect-request-timeout pos-int?)
+;; (s/def ::request-options/max-redirects int?)
+;; (s/def ::request-options/socket-timeout pos-int?)
 
-(s/def ::request-options/proxy any?)
-(s/def ::request-options/cookie-spec any?)
-(s/def ::request-options/local-address #(instance? InetAddress %))
+;; (s/def ::request-options/proxy any?)
+;; (s/def ::request-options/cookie-spec any?)
+;; (s/def ::request-options/local-address #(instance? InetAddress %))
 
-(alias 'sniffer-options (create-ns 'qbits.spandex.spec.sniffer-options))
-(s/def ::sniffer-options (s/keys :opt-un [::sniffer-options/sniff-interval
-                                          ::sniffer-options/sniff-after-failure-delay]))
-(s/def ::sniffer-options/sniff-interval int?)
-(s/def ::sniffer-options/sniff-after-failure-delay int?)
+;; (alias 'sniffer-options (create-ns 'qbits.spandex.spec.sniffer-options))
+;; (s/def ::sniffer-options (s/keys :opt-un [::sniffer-options/sniff-interval
+;;                                           ::sniffer-options/sniff-after-failure-delay]))
+;; (s/def ::sniffer-options/sniff-interval int?)
+;; (s/def ::sniffer-options/sniff-after-failure-delay int?)
 
-(alias 'request (create-ns 'qbits.spandex.spec.request))
-(s/def ::request (s/keys :req-un [::request/url]
-                         :opt-un [::request/scheme
-                                  ::request/method
-                                  ::request/headers
-                                  ::request/query-string
-                                  ::request/body
-                                  ::request/exception-handler]))
+;; (alias 'request (create-ns 'qbits.spandex.spec.request))
+;; (s/def ::request (s/keys :req-un [::request/url]
+;;                          :opt-un [::request/scheme
+;;                                   ::request/method
+;;                                   ::request/headers
+;;                                   ::request/query-string
+;;                                   ::request/body
+;;                                   ::request/exception-handler]))
 
-(s/def ::request/url #(satisfies? qbits.spandex.url/URL %))
-(s/def ::request/scheme #{:http :https})
-(s/def ::request/method #{:get :post :put :head})
-(s/def ::request/headers (s/map-of (s/or :kw keyword? :str string?)
-                                   string?))
-(s/def ::request/query-string (s/map-of (s/or :kw keyword? :str string?)
-                                        any?))
+;; (s/def ::request/url #(satisfies? qbits.spandex.url/URL %))
+;; (s/def ::request/scheme #{:http :https})
+;; (s/def ::request/method #{:get :post :put :head})
+;; (s/def ::request/headers (s/map-of (s/or :kw keyword? :str string?)
+;;                                    string?))
+;; (s/def ::request/query-string (s/map-of (s/or :kw keyword? :str string?)
+;;                                         any?))
 
-(s/def ::request/body (s/or :str string?
-                            :raw #(instance? qbits.spandex.Raw %)
-                            :stream #(instance? java.io.InputStream %)
-                            :edn any?))
+;; (s/def ::request/body (s/or :str string?
+;;                             :raw #(instance? qbits.spandex.Raw %)
+;;                             :stream #(instance? java.io.InputStream %)
+;;                             :edn any?))
 
-(s/def ::request/exception-handler
-  fn?
-  ;; (s/fspec :args (s/cat :throwable #(instance? Throwable %)))
-  )
+;; (s/def ::request/exception-handler
+;;   fn?
+;;   ;; (s/fspec :args (s/cat :throwable #(instance? Throwable %)))
+;;   )
 
-(alias 'response (create-ns 'qbits.spandex.spec.response))
-(s/def ::response (s/keys :req-un [::response/body
-                                   ::response/status
-                                   ::response/headers
-                                   ::response/host]))
+;; (alias 'response (create-ns 'qbits.spandex.spec.response))
+;; (s/def ::response (s/keys :req-un [::response/body
+;;                                    ::response/status
+;;                                    ::response/headers
+;;                                    ::response/host]))
 
-(s/def ::response/headers (s/map-of string? string?))
-(s/def ::response/status pos-int?)
-(s/def ::response/body (s/nilable any?)) ;; edn/clj?
-(s/def ::response/host any?) ;; to be refine
+;; (s/def ::response/headers (s/map-of string? string?))
+;; (s/def ::response/status pos-int?)
+;; (s/def ::response/body (s/nilable any?)) ;; edn/clj?
+;; (s/def ::response/host any?) ;; to be refine
 
-(s/def ::request-async
-  (s/merge ::request
-           (s/keys :opt-un [::success ::error ::response-consumer-factory])))
+;; (s/def ::request-async
+;;   (s/merge ::request
+;;            (s/keys :opt-un [::success ::error ::response-consumer-factory])))
 
-(s/def ::success fn?) ;; refine
-(s/def ::error fn?) ;; refine
+;; (s/def ::success fn?) ;; refine
+;; (s/def ::error fn?) ;; refine
 
-(s/fdef qbits.spandex/request
-        :args (s/cat :client ::client
-                     :options ::request)
-        :ret ::response)
+;; (s/fdef qbits.spandex/request
+;;         :args (s/cat :client ::client
+;;                      :options ::request)
+;;         :ret ::response)
 
-(s/fdef qbits.spandex/request-async
-        :args (s/cat :client ::client
-                     :options ::request-async))
+;; (s/fdef qbits.spandex/request-async
+;;         :args (s/cat :client ::client
+;;                      :options ::request-async))
 
-(s/fdef qbits.spandex/request-chan
-        :args (s/cat :client ::client
-                     :options ::request-async)
-        :ret ::chan)
+;; (s/fdef qbits.spandex/request-chan
+;;         :args (s/cat :client ::client
+;;                      :options ::request-async)
+;;         :ret ::chan)
 
-(s/fdef qbits.spandex/chunks->body
-        :args (s/cat :fragments (s/coll-of map?))
-        :ret string?)
+;; (s/fdef qbits.spandex/chunks->body
+;;         :args (s/cat :fragments (s/coll-of map?))
+;;         :ret string?)
 
-(s/def ::ttl int?)
-(s/def ::ch int?)
-(s/fdef qbits.spandex/scroll-chan
-        :args (s/cat :client ::client
-                     :options (s/and ::request (s/keys :opt-un [::ttl ::ch])))
-        :ret ::chan)
+;; (s/def ::ttl int?)
+;; (s/def ::ch int?)
+;; (s/fdef qbits.spandex/scroll-chan
+;;         :args (s/cat :client ::client
+;;                      :options (s/and ::request (s/keys :opt-un [::ttl ::ch])))
+;;         :ret ::chan)
 
-(s/def ::input-ch ::chan)
-(s/def ::output-ch ::chan)
-(s/def ::request-ch ::chan)
-(s/def ::flush-interval pos-int?)
-(s/def ::flush-threshold pos-int?)
-(s/def ::max-concurrent-requests pos-int?)
-(s/def ::bulk-chan-options (s/and ::request
-                                  (s/keys :opt-un [::input-ch
-                                                   ::output-ch
-                                                   ::flush-threshold
-                                                   ::flush-interval
-                                                   ::max-concurrent-requests])))
-(s/fdef qbits.spandex/bulk-chan
-        :args (s/cat :client ::client
-                     :options ::bulk-chan-options)
-        :ret (s/keys :req-un [::input-ch ::output-ch ::request-ch]))
+;; (s/def ::input-ch ::chan)
+;; (s/def ::output-ch ::chan)
+;; (s/def ::request-ch ::chan)
+;; (s/def ::flush-interval pos-int?)
+;; (s/def ::flush-threshold pos-int?)
+;; (s/def ::max-concurrent-requests pos-int?)
+;; (s/def ::bulk-chan-options (s/and ::request
+;;                                   (s/keys :opt-un [::input-ch
+;;                                                    ::output-ch
+;;                                                    ::flush-threshold
+;;                                                    ::flush-interval
+;;                                                    ::max-concurrent-requests])))
+;; (s/fdef qbits.spandex/bulk-chan
+;;         :args (s/cat :client ::client
+;;                      :options ::bulk-chan-options)
+;;         :ret (s/keys :req-un [::input-ch ::output-ch ::request-ch]))
 
-;; utils
-(s/fdef qbits.spandex.url/encode
-        :args (s/cat :parts (s/* (s/nilable #(satisfies? qbits.spandex.url/URLFragment %))))
-        :ret string?)
+;; ;; utils
+;; (s/fdef qbits.spandex.url/encode
+;;         :args (s/cat :parts (s/* (s/nilable #(satisfies? qbits.spandex.url/URLFragment %))))
+;;         :ret string?)

--- a/src/clj/qbits/spandex/url.clj
+++ b/src/clj/qbits/spandex/url.clj
@@ -23,7 +23,11 @@
   clojure.lang.Sequential
   (encode-fragment [value]
     ;; multi index fragment
-    (transduce x-fragment-interpose-comma string-builder value))
+    (let [interposed (->> value
+                          (remove nil?)
+                          (map encode-fragment)
+                          (interpose ","))]
+      (string-builder (reduce string-builder (string-builder) interposed))))
 
   clojure.lang.Keyword
   (encode-fragment [value] (name value))
@@ -34,15 +38,6 @@
   Object
   (encode-fragment [value] (str value)))
 
-(def ^:no-doc x-fragment-interpose-comma
-  (comp (remove nil?)
-        (map encode-fragment)
-        (interpose ",")))
-
-(def ^:no-doc x-fragment-interpose-slash
-  (comp (remove nil?)
-        (map encode-fragment)
-        (interpose "/")))
 
 (extend-protocol URL
   String
@@ -50,9 +45,11 @@
 
   Object
   (encode [parts]
-    (transduce x-fragment-interpose-slash
-               url-string-builder
-               parts))
+    (let [interposed (->> parts
+                          (remove nil?)
+                          (map encode-fragment)
+                          (interpose "/"))]
+      (string-builder (reduce url-string-builder (url-string-builder) interposed))))
 
   nil
   (encode [_] "/"))


### PR DESCRIPTION
Still pretty messy - WIP

Some features won't work properly:
- scrolling chan
- sniffer

Clojure language features that don't exist in 1.5 that had to be replaced:
- transduce
- string/index-of
- run!